### PR TITLE
Restructure to allow for the time hash in query string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,15 @@ $client->setFormatter(new JsonFormatter);
 Returns a paginated list of cards. The list of cards can be filtered down using the `CardsConfig` object. See below example for all filtering options. All filtering options are **optional**. If a filter is not valid, an `InvalidCardConfigException` exception in thrown.
 For a full list of options please see the API [documentation](https://fabdb.net/resources/api).
 
+Please note that the official API docs seems to be incomplete. We've done our best to fill in the missing fields and values.
+
 `FleshAndBlood` object example:
 ```php
 use Memuya\Fab\Enums\Set;
 use Memuya\Fab\Enums\Pitch;
 use Memuya\Fab\Enums\Rarity;
+use Memuya\Fab\Enums\Talent;
+use Memuya\Fab\Enums\CardType;
 use Memuya\Fab\Enums\HeroClass;
 use Memuya\Fab\Exceptions\InvalidCardConfigException;
 
@@ -73,6 +77,8 @@ try {
         'class' => HeroClass::Brute,
         'rarity' => Rarity::Common,
         'set' => Set::WelcomeToRathe,
+        'talent' => Talent::None,
+        'cardType' => CardType::NonAttack,
     ]);
 } catch (InvalidCardConfigException $ex) {
     // Handle exception...
@@ -101,6 +107,8 @@ try {
                 'class' => HeroClass::Brute,
                 'rarity' => Rarity::Common,
                 'set' => Set::WelcomeToRathe,
+                'talent' => Talent::None,
+                'cardType' => CardType::NonAttack,
             ])
         )
     );

--- a/src/Attributes/RequestBody.php
+++ b/src/Attributes/RequestBody.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Memuya\Fab\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class RequestBody
+{
+    
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -16,6 +16,13 @@ class Client
      * @param string
      */
     const BASE_URL = 'https://api.fabdb.net';
+    
+    /**
+     * Hashing algorithm used in the request.
+     * 
+     * @var string
+     */
+    const HASING_ALGORITHM = 'sha512';
 
     /**
      * Determines if the response should be returned raw, without any transformation.
@@ -158,7 +165,7 @@ class Client
      */
     private function generateTimeHash(Config $config): string
     {
-        return hash('sha512', $this->secret.$config->time);
+        return hash(self::HASING_ALGORITHM, $this->secret.$config->time);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -77,7 +77,7 @@ class Client
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $endpoint->getHttpMethod()->name);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
-            "Accept: {$this->formatter->getContentType()}",
+            "Accept: {$this->formatter->getContentType()->value}",
             "Authorization: Bearer {$this->token}",
         ]);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -23,17 +23,12 @@ class Client
     private bool $rawResponse = false;
 
     /**
-     * @var Formatter
-     */
-    private Formatter $formatter;
-
-    /**
      * The API token provided by fabdb.net.
      *
      * @var string
      */
     private string $token;
-
+    
     /**
      * The API secret provided by fabdb.net.
      *
@@ -42,15 +37,20 @@ class Client
     private string $secret;
 
     /**
+     * @var Formatter
+     */
+    private Formatter $formatter;
+
+    /**
      * @param string $token Token generated from https://fabdb.net/resources/api
      * @param string $secret Secret generated from https://fabdb.net/resources/api
      * @param Formatter $formatter
      */
     public function __construct(string $token, string $secret, Formatter $formatter = new JsonFormatter)
     {
-        $this->formatter = $formatter;
         $this->token = $token;
         $this->secret = $secret;
+        $this->formatter = $formatter;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -134,16 +134,11 @@ class Client
      */
     private function generateEndpointUrl(Endpoint $endpoint): string
     {
-        $query_string = http_build_query([
-            ...$endpoint->getConfig()->getQueryAsArray(),
-            'hash' => $this->generateTimeHash($endpoint)
-        ]);
-
         return sprintf(
             '%s%s?%s',
             self::BASE_URL,
             $endpoint->getRoute(),
-            $query_string
+            $this->buildQueryString($endpoint)
         );
     }
 
@@ -156,5 +151,19 @@ class Client
     private function generateTimeHash(Endpoint $endpoint): string
     {
         return $this->secret.hash('sha512', $endpoint->getConfig()->time);
+    }
+
+    /**
+     * Build the query string to use used with the API endpoint.
+     *
+     * @param Endpoint $endpoint
+     * @return string
+     */
+    private function buildQueryString(Endpoint $endpoint): string
+    {
+        return http_build_query([
+            ...$endpoint->getConfig()->getQueryAsArray(),
+            'hash' => $this->generateTimeHash($endpoint)
+        ]);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -22,7 +22,7 @@ class Client
      * 
      * @var string
      */
-    const HASING_ALGORITHM = 'sha512';
+    const HASHING_ALGORITHM = 'sha512';
 
     /**
      * Determines if the response should be returned raw, without any transformation.
@@ -165,7 +165,7 @@ class Client
      */
     private function generateTimeHash(Config $config): string
     {
-        return hash(self::HASING_ALGORITHM, $this->secret.$config->time);
+        return hash(self::HASHING_ALGORITHM, $this->secret.$config->time);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -162,7 +162,7 @@ class Client
     private function buildQueryString(Endpoint $endpoint): string
     {
         return http_build_query([
-            ...$endpoint->getConfig()->getQueryAsArray(),
+            ...$endpoint->getConfig()->getQueryStringValues(),
             'hash' => $this->generateTimeHash($endpoint)
         ]);
     }

--- a/src/Endpoints/BaseConfig.php
+++ b/src/Endpoints/BaseConfig.php
@@ -58,7 +58,7 @@ abstract class BaseConfig
      *
      * @return array
      */
-    public function getQueryAsArray(): array
+    public function getQueryStringValues(): array
     {
         $reflection = new ReflectionClass($this);
         $query_string_array = [];
@@ -84,20 +84,5 @@ abstract class BaseConfig
         }
 
         return $query_string_array;
-    }
-
-    /**
-     * Convert the config into a usable query string.
-     *
-     * @return string
-     */
-    public function toQueryString(): string
-    {
-        return http_build_query($this->getQueryAsArray());
-    }
-
-    public function __toString()
-    {
-        return $this->toQueryString();
     }
 }

--- a/src/Endpoints/BaseConfig.php
+++ b/src/Endpoints/BaseConfig.php
@@ -7,8 +7,16 @@ use ReflectionClass;
 use ReflectionProperty;
 use Memuya\Fab\Attributes\QueryString;
 
-class BaseConfig
+abstract class BaseConfig
 {
+    /**
+     * The UNIX timestamp to be sent with all requests.
+     *
+     * @var int
+     */
+    #[QueryString]
+    public int $time;
+
     /**
      * Set up all the properties on the child class with the data provided.
      * 
@@ -17,6 +25,7 @@ class BaseConfig
     public function __construct(array $config = [])
     {
         $this->setConfigFromArray($config);
+        $this->time = time();
     }
 
     /**
@@ -45,11 +54,11 @@ class BaseConfig
     }
 
     /**
-     * Convert the config into a usable query string.
+     * Return the options that will be a part of the query string as an array.
      *
-     * @return string
+     * @return array
      */
-    public function toQueryString(): string
+    public function getQueryAsArray(): array
     {
         $reflection = new ReflectionClass($this);
         $query_string_array = [];
@@ -74,7 +83,17 @@ class BaseConfig
             $query_string_array[$property_name] = $value;
         }
 
-        return http_build_query($query_string_array);
+        return $query_string_array;
+    }
+
+    /**
+     * Convert the config into a usable query string.
+     *
+     * @return string
+     */
+    public function toQueryString(): string
+    {
+        return http_build_query($this->getQueryAsArray());
     }
 
     public function __toString()

--- a/src/Endpoints/Card/CardConfig.php
+++ b/src/Endpoints/Card/CardConfig.php
@@ -2,9 +2,9 @@
 
 namespace Memuya\Fab\Endpoints\Card;
 
-use Memuya\Fab\Endpoints\BaseConfig;
+use Memuya\Fab\Endpoints\Config;
 
-class CardConfig extends BaseConfig
+class CardConfig extends Config
 {
    public string $identifier;
 }

--- a/src/Endpoints/Card/CardEndpoint.php
+++ b/src/Endpoints/Card/CardEndpoint.php
@@ -24,4 +24,9 @@ class CardEndpoint implements Endpoint
     {
         return HttpMethod::GET;
     }
+
+    public function getConfig(): CardConfig
+    {
+        return $this->config;
+    }
 }

--- a/src/Endpoints/Cards/CardsConfig.php
+++ b/src/Endpoints/Cards/CardsConfig.php
@@ -12,6 +12,11 @@ use Memuya\Fab\Exceptions\InvalidCardConfigException;
 
 class CardsConfig extends BaseConfig
 {
+    /**
+     * The maximum amount of records allowed to be returned from the API.
+     * 
+     * @var int
+     */
     const PER_PAGE_MAX = 100;
 
     /**

--- a/src/Endpoints/Cards/CardsConfig.php
+++ b/src/Endpoints/Cards/CardsConfig.php
@@ -5,12 +5,13 @@ namespace Memuya\Fab\Endpoints\Cards;
 use Memuya\Fab\Enums\Set;
 use Memuya\Fab\Enums\Pitch;
 use Memuya\Fab\Enums\Rarity;
+use Memuya\Fab\Enums\Talent;
 use Memuya\Fab\Enums\HeroClass;
-use Memuya\Fab\Endpoints\BaseConfig;
+use Memuya\Fab\Endpoints\Config;
 use Memuya\Fab\Attributes\QueryString;
 use Memuya\Fab\Exceptions\InvalidCardConfigException;
 
-class CardsConfig extends BaseConfig
+class CardsConfig extends Config
 {
     /**
      * The maximum amount of records allowed to be returned from the API.
@@ -82,6 +83,14 @@ class CardsConfig extends BaseConfig
      */
     #[QueryString]
     public Set $set;
+
+    /**
+     * The talent to filter by.
+     *
+     * @var Talent
+     */
+    #[QueryString]
+    public Talent $talent;
 
     public function setPerPage(int $per_page): void
     {

--- a/src/Endpoints/Cards/CardsConfig.php
+++ b/src/Endpoints/Cards/CardsConfig.php
@@ -6,6 +6,7 @@ use Memuya\Fab\Enums\Set;
 use Memuya\Fab\Enums\Pitch;
 use Memuya\Fab\Enums\Rarity;
 use Memuya\Fab\Enums\Talent;
+use Memuya\Fab\Enums\CardType;
 use Memuya\Fab\Enums\HeroClass;
 use Memuya\Fab\Endpoints\Config;
 use Memuya\Fab\Attributes\QueryString;
@@ -91,6 +92,14 @@ class CardsConfig extends Config
      */
     #[QueryString]
     public Talent $talent;
+
+    /**
+     * The card type to filter by.
+     *
+     * @var CardType
+     */
+    #[QueryString]
+    public CardType $cardType;
 
     public function setPerPage(int $per_page): void
     {

--- a/src/Endpoints/Cards/CardsEndpoint.php
+++ b/src/Endpoints/Cards/CardsEndpoint.php
@@ -17,11 +17,16 @@ class CardsEndpoint implements Endpoint
 
     public function getRoute(): string
     {
-        return sprintf('/cards?%s', $this->config->toQueryString());
+        return sprintf('/cards');
     }
 
     public function getHttpMethod(): HttpMethod
     {
         return HttpMethod::GET;
+    }
+
+    public function getConfig(): CardsConfig
+    {
+        return $this->config;
     }
 }

--- a/src/Endpoints/Cards/CardsEndpoint.php
+++ b/src/Endpoints/Cards/CardsEndpoint.php
@@ -17,7 +17,7 @@ class CardsEndpoint implements Endpoint
 
     public function getRoute(): string
     {
-        return sprintf('/cards');
+        return '/cards';
     }
 
     public function getHttpMethod(): HttpMethod

--- a/src/Endpoints/Config.php
+++ b/src/Endpoints/Config.php
@@ -41,18 +41,7 @@ abstract class Config
     public function setConfigFromArray(array $config): void
     {
         foreach ($config as $property => $value) {
-            if (property_exists($this, $property)) {
-                $method = sprintf('set%s', Str::toPascalCase($property));
-
-                // If there's a setter for the given property, we'll use that instead.
-                if (method_exists($this, $method)) {
-                    $this->{$method}($value);
-
-                    continue;
-                }
-
-                $this->{$property} = $value;
-            }
+            $this->setProperty($property, $value);
         }
     }
 
@@ -128,5 +117,30 @@ abstract class Config
         }
 
         return $value;
+    }
+
+    /**
+     * Set a property's value, using a setter method if found.
+     *
+     * @param string $property
+     * @param mixed $value
+     * @return void
+     */
+    private function setProperty(string $property, mixed $value): void
+    {
+        if (! property_exists($this, $property)) {
+            return;
+        }
+
+        $method = sprintf('set%s', Str::toPascalCase($property));
+
+        // If there's a setter for the given property, we'll use that instead.
+        if (method_exists($this, $method)) {
+            $this->{$method}($value);
+
+            return;
+        }
+
+        $this->{$property} = $value;
     }
 }

--- a/src/Endpoints/Config.php
+++ b/src/Endpoints/Config.php
@@ -57,6 +57,26 @@ abstract class Config
     }
 
     /**
+     * Return the options that will be a part of the query string as an array.
+     *
+     * @return array
+     */
+    public function getQueryStringValues(): array
+    {
+        return $this->getValuesFor(QueryString::class);
+    }
+
+    /**
+     * Return the options that will be a part of the request body as an array.
+     *
+     * @return array
+     */
+    public function getRequestBodyValues(): array
+    {
+        return $this->getValuesFor(RequestBody::class);
+    }
+
+    /**
      * Return the values associated to the attribute passed in.
      *
      * @param string $attribute
@@ -82,26 +102,6 @@ abstract class Config
         }
 
         return $data;
-    }
-
-    /**
-     * Return the options that will be a part of the query string as an array.
-     *
-     * @return array
-     */
-    public function getQueryStringValues(): array
-    {
-        return $this->getValuesFor(QueryString::class);
-    }
-
-    /**
-     * Return the options that will be a part of the request body as an array.
-     *
-     * @return array
-     */
-    public function getRequestBodyValues(): array
-    {
-        return $this->getValuesFor(RequestBody::class);
     }
 
     /**

--- a/src/Endpoints/Config.php
+++ b/src/Endpoints/Config.php
@@ -77,18 +77,8 @@ abstract class Config
             if (! isset($this->{$property_name})) {
                 continue;
             }
-            
-            $value = $this->{$property_name};
 
-            if (is_object($value)) {
-                $value = match (get_class($this->{$property_name})) {
-                    BackedEnum::class => $value->value,
-                    UnitEnum::class => $value->name,
-                    default => $value,
-                };
-            }
-
-            $data[$property_name] = $value;
+            $data[$property_name] = $this->extractValueFromProperty($property_name);
         }
 
         return $data;
@@ -112,5 +102,26 @@ abstract class Config
     public function getRequestBodyValues(): array
     {
         return $this->getValuesFor(RequestBody::class);
+    }
+
+    /**
+     * Extract the value from the given property name. Especially useful for enums.
+     *
+     * @param string $property_name
+     * @return mixed
+     */
+    private function extractValueFromProperty(string $property_name): mixed
+    {
+        $value = $this->{$property_name};
+
+        if ($value instanceof BackedEnum) {
+            return $value->value;
+        }
+        
+        if ($value instanceof UnitEnum) {
+            return $value->name;
+        }
+
+        return $value;
     }
 }

--- a/src/Endpoints/Config.php
+++ b/src/Endpoints/Config.php
@@ -79,7 +79,7 @@ abstract class Config
             
             $value = $this->{$property_name} instanceof BackedEnum
                 ? $this->{$property_name}->value 
-                : $this->{$property_name};
+                : $this->{$property_name}->name;
 
             $data[$property_name] = $value;
         }

--- a/src/Endpoints/Config.php
+++ b/src/Endpoints/Config.php
@@ -2,14 +2,12 @@
 
 namespace Memuya\Fab\Endpoints;
 
-use UnitEnum;
-use BackedEnum;
-use Stringable;
 use ReflectionClass;
 use ReflectionProperty;
 use Memuya\Fab\Utilities\Str;
 use Memuya\Fab\Attributes\QueryString;
 use Memuya\Fab\Attributes\RequestBody;
+use Memuya\Fab\Utilities\Extract\Value;
 use Memuya\Fab\Exceptions\PropertyNotSetException;
 
 abstract class Config
@@ -107,21 +105,7 @@ abstract class Config
             throw new PropertyNotSetException(sprintf('Property "%s" not set.', $property_name));
         }
 
-        $value = $this->{$property_name};
-
-        if ($value instanceof BackedEnum) {
-            return $value->value;
-        }
-        
-        if ($value instanceof UnitEnum) {
-            return $value->name;
-        }
-
-        if ($value instanceof Stringable) {
-            return (string) $value;
-        }
-
-        return $value;
+        return Value::from($this->{$property_name})->extract();
     }
 
     /**
@@ -138,7 +122,7 @@ abstract class Config
         }
 
         $method = sprintf('set%s', Str::toPascalCase($property));
-        
+
         if (method_exists($this, $method)) {
             $this->{$method}($value);
 

--- a/src/Endpoints/Config.php
+++ b/src/Endpoints/Config.php
@@ -9,6 +9,7 @@ use ReflectionProperty;
 use Memuya\Fab\Utilities\Str;
 use Memuya\Fab\Attributes\QueryString;
 use Memuya\Fab\Attributes\RequestBody;
+use UnitEnum;
 
 abstract class Config
 {
@@ -77,9 +78,15 @@ abstract class Config
                 continue;
             }
             
-            $value = $this->{$property_name} instanceof BackedEnum
-                ? $this->{$property_name}->value 
-                : $this->{$property_name}->name;
+            $value = $this->{$property_name};
+
+            if (is_object($value)) {
+                $value = match (get_class($this->{$property_name})) {
+                    BackedEnum::class => $value->value,
+                    UnitEnum::class => $value->name,
+                    default => $value,
+                };
+            }
 
             $data[$property_name] = $value;
         }

--- a/src/Endpoints/Config.php
+++ b/src/Endpoints/Config.php
@@ -4,6 +4,7 @@ namespace Memuya\Fab\Endpoints;
 
 use UnitEnum;
 use BackedEnum;
+use Stringable;
 use ReflectionClass;
 use ReflectionProperty;
 use Memuya\Fab\Utilities\Str;
@@ -116,6 +117,10 @@ abstract class Config
             return $value->name;
         }
 
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+
         return $value;
     }
 
@@ -133,8 +138,7 @@ abstract class Config
         }
 
         $method = sprintf('set%s', Str::toPascalCase($property));
-
-        // If there's a setter for the given property, we'll use that instead.
+        
         if (method_exists($this, $method)) {
             $this->{$method}($value);
 

--- a/src/Endpoints/Deck/DeckConfig.php
+++ b/src/Endpoints/Deck/DeckConfig.php
@@ -2,9 +2,9 @@
 
 namespace Memuya\Fab\Endpoints\Deck;
 
-use Memuya\Fab\Endpoints\BaseConfig;
+use Memuya\Fab\Endpoints\Config;
 
-class DeckConfig extends BaseConfig
+class DeckConfig extends Config
 {
    public string $slug;
 }

--- a/src/Endpoints/Deck/DeckEndpoint.php
+++ b/src/Endpoints/Deck/DeckEndpoint.php
@@ -24,4 +24,9 @@ class DeckEndpoint implements Endpoint
     {
         return HttpMethod::GET;
     }
+
+    public function getConfig(): DeckConfig
+    {
+        return $this->config;
+    }
 }

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -3,7 +3,7 @@
 namespace Memuya\Fab\Endpoints;
 
 use Memuya\Fab\Enums\HttpMethod;
-use Memuya\Fab\Endpoints\BaseConfig;
+use Memuya\Fab\Endpoints\Config;
 
 interface Endpoint
 {
@@ -24,7 +24,7 @@ interface Endpoint
     /**
      * Return the config options used for the endpoint.
      *
-     * @return BaseConfig
+     * @return Config
      */
-    public function getConfig(): BaseConfig;
+    public function getConfig(): Config;
 }

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -3,6 +3,7 @@
 namespace Memuya\Fab\Endpoints;
 
 use Memuya\Fab\Enums\HttpMethod;
+use Memuya\Fab\Endpoints\BaseConfig;
 
 interface Endpoint
 {
@@ -19,4 +20,11 @@ interface Endpoint
      * @return HttpMethod
      */
     public function getHttpMethod(): HttpMethod;
+
+    /**
+     * Return the config options used for the endpoint.
+     *
+     * @return BaseConfig
+     */
+    public function getConfig(): BaseConfig;
 }

--- a/src/Enums/CardType.php
+++ b/src/Enums/CardType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Memuya\Fab\Enums;
+
+enum CardType: string
+{
+    case NonAttack = 'non-attack';
+    case AttackAction = 'attack action';
+    case AttackReaction = 'attack reaction';
+    case DefenseReaction = 'defense reaction';
+    case Equipment = 'equipment';
+    case Hero = 'hero';
+    case Instant = 'instant';
+    case Item = 'item';
+    case Weapon = 'weapon';
+}

--- a/src/Enums/HttpContentType.php
+++ b/src/Enums/HttpContentType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Memuya\Fab\Enums;
+
+enum HttpContentType: string
+{
+    case CSV = 'text/css';
+    case JSON = 'application/json';
+    case XML = 'application/xml';
+}

--- a/src/Enums/HttpMethod.php
+++ b/src/Enums/HttpMethod.php
@@ -4,5 +4,9 @@ namespace Memuya\Fab\Enums;
 
 enum HttpMethod
 {
+    case DELETE;
     case GET;
+    case PATCH;
+    case POST;
+    case PUT;
 }

--- a/src/Enums/Talent.php
+++ b/src/Enums/Talent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Memuya\Fab\Enums;
+
+enum Talent: string
+{
+    case None = 'none';
+    case Draconic = 'draconic';
+    case Earth = 'earth';
+    case Elemental = 'elemental';
+    case Ice = 'ice';
+    case Light = 'light';
+    case Lightning = 'lightning';
+    case Shadow = 'shadow';
+}

--- a/src/Exceptions/PropertyNotSetException.php
+++ b/src/Exceptions/PropertyNotSetException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Memuya\Fab\Exceptions;
+
+use Exception;
+
+class PropertyNotSetException extends Exception
+{
+
+}

--- a/src/FleshAndBlood.php
+++ b/src/FleshAndBlood.php
@@ -34,9 +34,9 @@ class FleshAndBlood
      * Return a paginated list of cards.
      *
      * @param array $config
-     * @return stdClass
+     * @return mixed  Changes depending on the formatter used in Client
      */
-    public function getCards(array $config = []): stdClass
+    public function getCards(array $config = []): mixed
     {
         return $this->client->sendRequest(
             new CardsEndpoint(new CardsConfig($config))
@@ -47,9 +47,9 @@ class FleshAndBlood
      * Return information on a card.
      *
      * @param string $identifier
-     * @return stdClass
+     * @return mixed  Changes depending on the formatter used in Client
      */
-    public function getCard(string $identifier): stdClass
+    public function getCard(string $identifier): mixed
     {
         return $this->client->sendRequest(
             new CardEndpoint(new CardConfig(['identifier' => $identifier]))
@@ -60,9 +60,9 @@ class FleshAndBlood
      * Return information on the given deck.
      *
      * @param string $slug
-     * @return stdClass
+     * @return mixed  Changes depending on the formatter used in Client
      */
-    public function getDeck(string $slug): stdClass
+    public function getDeck(string $slug): mixed
     {
         return $this->client->sendRequest(
             new DeckEndpoint(new DeckConfig(['slug' => $slug]))

--- a/src/FleshAndBlood.php
+++ b/src/FleshAndBlood.php
@@ -14,7 +14,7 @@ use Memuya\Fab\Endpoints\Cards\CardsEndpoint;
 class FleshAndBlood
 {
     /**
-     * The Client used to communicate with the API.
+     * The client used to communicate with the API.
      *
      * @var Client
      */

--- a/src/Formatters/CsvFormatter.php
+++ b/src/Formatters/CsvFormatter.php
@@ -3,15 +3,16 @@
 namespace Memuya\Fab\Formatters;
 
 use Memuya\Fab\Formatters\Formatter;
+use Memuya\Fab\Enums\HttpContentType;
 
 class CsvFormatter implements Formatter
 {
     /**
      * @inheritDoc
      */
-    public function getContentType(): string
+    public function getContentType(): HttpContentType
     {
-        return 'text/csv';
+        return HttpContentType::CSV;
     }
 
     /**

--- a/src/Formatters/Formatter.php
+++ b/src/Formatters/Formatter.php
@@ -2,14 +2,16 @@
 
 namespace Memuya\Fab\Formatters;
 
+use Memuya\Fab\Enums\HttpContentType;
+
 interface Formatter
 {
     /**
      * The content type of the response.
      *
-     * @return string
+     * @return HttpContentType
      */
-    public function getContentType(): string;
+    public function getContentType(): HttpContentType;
 
     /**
      * Format the given data.

--- a/src/Formatters/JsonFormatter.php
+++ b/src/Formatters/JsonFormatter.php
@@ -3,15 +3,16 @@
 namespace Memuya\Fab\Formatters;
 
 use Memuya\Fab\Formatters\Formatter;
+use Memuya\Fab\Enums\HttpContentType;
 
 class JsonFormatter implements Formatter
 {
     /**
      * @inheritDoc
      */
-    public function getContentType(): string
+    public function getContentType(): HttpContentType
     {
-        return 'application/json';
+        return HttpContentType::JSON;
     }
 
     /**

--- a/src/Formatters/XmlFormatter.php
+++ b/src/Formatters/XmlFormatter.php
@@ -3,15 +3,16 @@
 namespace Memuya\Fab\Formatters;
 
 use Memuya\Fab\Formatters\Formatter;
+use Memuya\Fab\Enums\HttpContentType;
 
 class XmlFormatter implements Formatter
 {
     /**
      * @inheritDoc
      */
-    public function getContentType(): string
+    public function getContentType(): HttpContentType
     {
-        return 'application/xml';
+        return HttpContentType::XML;
     }
 
     /**

--- a/src/Utilities/Extract/Type/Type.php
+++ b/src/Utilities/Extract/Type/Type.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Memuya\Fab\Utilities\Extract\Type;
+
+interface Type
+{
+    /**
+     * Extract the value from a property.
+     *
+     * @return mixed
+     */
+    public function extract(): mixed;
+}

--- a/src/Utilities/Extract/Type/TypeBackedEnum.php
+++ b/src/Utilities/Extract/Type/TypeBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Memuya\Fab\Utilities\Extract\Type;
+
+use BackedEnum;
+
+class TypeBackedEnum implements Type
+{
+    private BackedEnum $enum;
+    
+    public function __construct(BackedEnum $enum)
+    {
+        $this->enum = $enum;
+    }
+
+    public function extract(): mixed
+    {
+        return $this->enum->value;
+    }
+}

--- a/src/Utilities/Extract/Type/TypeStringable.php
+++ b/src/Utilities/Extract/Type/TypeStringable.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Memuya\Fab\Utilities\Extract\Type;
+
+use Stringable;
+
+class TypeStringable implements Type
+{
+    private Stringable $stringable;
+    
+    public function __construct(Stringable $stringable)
+    {
+        $this->stringable = $stringable;
+    }
+
+    public function extract(): string
+    {
+        return (string) $this->stringable;
+    }
+}

--- a/src/Utilities/Extract/Type/TypeUnitEnum.php
+++ b/src/Utilities/Extract/Type/TypeUnitEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Memuya\Fab\Utilities\Extract\Type;
+
+use UnitEnum;
+
+class TypeUnitEnum implements Type
+{
+    private UnitEnum $enum;
+    
+    public function __construct(UnitEnum $enum)
+    {
+        $this->enum = $enum;
+    }
+
+    public function extract(): mixed
+    {
+        return $this->enum->name;
+    }
+}

--- a/src/Utilities/Extract/Value.php
+++ b/src/Utilities/Extract/Value.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Memuya\Fab\Utilities\Extract;
+
+use UnitEnum;
+use Exception;
+use BackedEnum;
+use Stringable;
+use ReflectionClass;
+use Memuya\Fab\Utilities\Extract\Type\Type;
+use Memuya\Fab\Utilities\Extract\Type\TypeUnitEnum;
+use Memuya\Fab\Utilities\Extract\Type\TypeBackedEnum;
+use Memuya\Fab\Utilities\Extract\Type\TypeStringable;
+
+class Value
+{
+    /**
+     * The supported instance types that a value can be extracted from
+     * and their corresponding 'extractor' class.
+     *
+     * @return array
+     */
+    private static $supportedTypes = [
+        BackedEnum::class => TypeBackedEnum::class,
+        UnitEnum::class => TypeUnitEnum::class,
+        Stringable::class => TypeStringable::class,
+    ];
+
+    /**
+     * The 'value' that we need to try and extract from.
+     *
+     * @var mixed
+     */
+    private mixed $value;
+
+    public function __construct(mixed $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param mixed $value
+     * @return self
+     */
+    public static function from(mixed $value): self
+    {
+        return new self($value);
+    }
+
+    /**
+     * Extract the value depeneding on its instance type.
+     *
+     * @return mixed
+     */
+    public function extract(): mixed
+    {
+        foreach (self::$supportedTypes as $type => $extractor) {
+            if (! $this->value instanceof $type) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($extractor);
+
+            if (! $reflection->implementsInterface(Type::class)) {
+                throw new Exception(sprintf('"%s" does not implement interface "%s"', $extractor, Type::class));
+            }
+
+            return $reflection
+                ->newInstance($this->value)
+                ->extract();
+        }
+
+        return $this->value;
+    }
+}

--- a/src/Utilities/Str.php
+++ b/src/Utilities/Str.php
@@ -12,6 +12,32 @@ class Str
      */
     public static function toPascalCase(string $string): string
     {
-        return str_replace(' ', '', ucwords(str_replace(['_', '-'], ' ', $string)));
+        return self::removeWhiteSpace(
+            ucwords(self::replace($string, ['_', '-'], ' '))
+        );
+    }
+
+    /**
+     * Remove white space from the given string.
+     *
+     * @param string $string
+     * @return string
+     */
+    public static function removeWhiteSpace(string $string): string
+    {
+        return self::replace($string, ' ', '');
+    }
+
+    /**
+     * Replace characters with another in the given string.
+     *
+     * @param string $string
+     * @param string|array $search
+     * @param string $replace
+     * @return string
+     */
+    public static function replace(string $string, string|array $search, string $replace): string
+    {
+        return str_replace($search, $replace, $string);
     }
 }

--- a/src/Utilities/Str.php
+++ b/src/Utilities/Str.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Memuya\Fab\Utilities;
+
+class Str
+{
+    /**
+     * Convert the given string to PascalCase.
+     *
+     * @param string $string
+     * @return string
+     */
+    public static function toPascalCase(string $string): string
+    {
+        return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
+    }
+}

--- a/src/Utilities/Str.php
+++ b/src/Utilities/Str.php
@@ -12,6 +12,6 @@ class Str
      */
     public static function toPascalCase(string $string): string
     {
-        return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
+        return str_replace(' ', '', ucwords(str_replace(['_', '-'], ' ', $string)));
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -19,14 +19,21 @@ use Memuya\Fab\Formatters\XmlFormatter;
 final class ClientTest extends TestCase
 {
     private Client $client;
+    private $clientStub;
 
     public function setUp(): void
     {
-        $this->client = new Client;
+        $this->client = new Client('token', 'secret');
+        $this->clientStub = $this->createStub(Client::class);
     }
 
     public function testCanReturnRawResponse()
     {
+        // $this->clientStub->shouldReturnRaw();
+        // $this->clientStub->method('sendRequest')->willReturn('{"name": "test"}');
+
+        // $this->assertSame('test', $this->clientStub->sendRequest(new CardsEndpoint(new CardsConfig())));
+
         $this->client->shouldReturnRaw();
         $cards = $this->client->sendRequest(new CardsEndpoint(new CardsConfig()));
 
@@ -47,7 +54,9 @@ final class ClientTest extends TestCase
 
     public function testCanGetCardsWithDefaultConfig(): void
     {
-        $cards = $this->client->sendRequest(new CardsEndpoint(new CardsConfig()));
+        $this->clientStub->method('sendRequest')->willReturn((object) ['data' => []]);
+        $cards = $this->clientStub->sendRequest(new CardsEndpoint(new CardsConfig()));
+        // $cards = $this->client->sendRequest(new CardsEndpoint(new CardsConfig()));
 
         $this->assertInstanceOf(stdClass::class, $cards);
         $this->assertObjectHasAttribute('data', $cards);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,6 +4,7 @@ use Memuya\Fab\Client;
 use Memuya\Fab\Enums\Set;
 use Memuya\Fab\Enums\Pitch;
 use Memuya\Fab\Enums\Rarity;
+use Memuya\Fab\Enums\Talent;
 use Memuya\Fab\Enums\HeroClass;
 use PHPUnit\Framework\TestCase;
 use Memuya\Fab\Endpoints\Card\CardConfig;
@@ -73,6 +74,7 @@ final class ClientTest extends TestCase
             'class' => HeroClass::Brute,
             'rarity' => Rarity::Rare,
             'set' => Set::ArcaneRising,
+            'talent' => Talent::None,
         ];
 
         $cards = $this->client->sendRequest(

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -13,6 +13,7 @@ use Memuya\Fab\Endpoints\Card\CardEndpoint;
 use Memuya\Fab\Endpoints\Cards\CardsConfig;
 use Memuya\Fab\Endpoints\Deck\DeckEndpoint;
 use Memuya\Fab\Endpoints\Cards\CardsEndpoint;
+use Memuya\Fab\Enums\CardType;
 use Memuya\Fab\Formatters\CsvFormatter;
 use Memuya\Fab\Formatters\JsonFormatter;
 use Memuya\Fab\Formatters\XmlFormatter;
@@ -75,6 +76,7 @@ final class ClientTest extends TestCase
             'rarity' => Rarity::Rare,
             'set' => Set::ArcaneRising,
             'talent' => Talent::None,
+            'cardType' => CardType::AttackReaction,
         ];
 
         $cards = $this->client->sendRequest(

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -44,13 +44,13 @@ final class ClientTest extends TestCase
 
     public function testCanChangeResponseFormat()
     {
-        $this->client->setFormatter(new CsvFormatter);
+        $this->client->setFormatter(new CsvFormatter());
         $this->assertInstanceOf(CsvFormatter::class, $this->client->getFormatter());
 
-        $this->client->setFormatter(new XmlFormatter);
+        $this->client->setFormatter(new XmlFormatter());
         $this->assertInstanceOf(XmlFormatter::class, $this->client->getFormatter());
 
-        $this->client->setFormatter(new JsonFormatter);
+        $this->client->setFormatter(new JsonFormatter());
         $this->assertInstanceOf(JsonFormatter::class, $this->client->getFormatter());
     }
 

--- a/tests/Endpoints/Cards/CardsConfigTest.php
+++ b/tests/Endpoints/Cards/CardsConfigTest.php
@@ -75,6 +75,6 @@ final class CardsConfigTest extends TestCase
     {
         $config = new CardsConfig;
 
-        $this->assertSame('page=1', $config->toQueryString());
+        $this->assertSame(1, $config->page);
     }
 }

--- a/tests/Endpoints/Cards/CardsEndpointTest.php
+++ b/tests/Endpoints/Cards/CardsEndpointTest.php
@@ -11,6 +11,6 @@ final class CardsEndpointTest extends TestCase
         $endpoint = new CardsEndpoint(new CardsConfig(['cost' => '2']));
 
         $this->assertIsString($endpoint->getRoute());
-        $this->assertSame('/cards?page=1&cost=2', $endpoint->getRoute());
+        $this->assertSame('/cards', $endpoint->getRoute());
     }
 }

--- a/tests/FleshAndBloodTest.php
+++ b/tests/FleshAndBloodTest.php
@@ -10,7 +10,7 @@ final class FleshAndBloodTest extends TestCase
 
     public function setUp(): void
     {
-        $this->fab = new FleshAndBlood(new Client);
+        $this->fab = new FleshAndBlood(new Client('token', 'secret'));
     }
 
     public function testCanGetCards()

--- a/tests/Formatters/CsvFormatterTest.php
+++ b/tests/Formatters/CsvFormatterTest.php
@@ -1,20 +1,21 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use Memuya\Fab\Enums\HttpContentType;
 use Memuya\Fab\Formatters\CsvFormatter;
 
 final class CsvFormatterTest extends TestCase
 {
     public function testContentTypeIsApplicationJson()
     {
-        $formatter = new CsvFormatter;
+        $formatter = new CsvFormatter();
 
-        $this->assertSame('text/csv', $formatter->getContentType());
+        $this->assertSame(HttpContentType::CSV, $formatter->getContentType());
     }
 
     public function testCanFormatStringCsv()
     {
-        $formatter = new CsvFormatter;
+        $formatter = new CsvFormatter();
 
         $this->assertIsString($formatter->format('one,two,three'));
     }

--- a/tests/Formatters/JsonFormatterTest.php
+++ b/tests/Formatters/JsonFormatterTest.php
@@ -1,20 +1,21 @@
 <?php
 
-use Memuya\Fab\Formatters\JsonFormatter;
 use PHPUnit\Framework\TestCase;
+use Memuya\Fab\Enums\HttpContentType;
+use Memuya\Fab\Formatters\JsonFormatter;
 
 final class JsonFormatterTest extends TestCase
 {
     public function testContentTypeIsApplicationJson()
     {
-        $formatter = new JsonFormatter;
+        $formatter = new JsonFormatter();
 
-        $this->assertSame('application/json', $formatter->getContentType());
+        $this->assertSame(HttpContentType::JSON, $formatter->getContentType());
     }
 
     public function testCanFormatStringToJsonArray()
     {
-        $formatter = new JsonFormatter;
+        $formatter = new JsonFormatter();
         $json = $formatter->format('{"key": "value"}');
 
         $this->assertInstanceOf(stdClass::class, $json);

--- a/tests/Formatters/XmlFormatterTest.php
+++ b/tests/Formatters/XmlFormatterTest.php
@@ -1,20 +1,21 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use Memuya\Fab\Enums\HttpContentType;
 use Memuya\Fab\Formatters\XmlFormatter;
 
 final class XmlFormatterTest extends TestCase
 {
     public function testContentTypeIsApplicationJson()
     {
-        $formatter = new XmlFormatter;
+        $formatter = new XmlFormatter();
 
-        $this->assertSame('application/xml', $formatter->getContentType());
+        $this->assertSame(HttpContentType::XML, $formatter->getContentType());
     }
 
     public function testCanFormatStringToSimpleXMLElement()
     {
-        $formatter = new XmlFormatter;
+        $formatter = new XmlFormatter();
 
         $this->assertInstanceOf(
             SimpleXMLElement::class,

--- a/tests/Utilities/StrTest.php
+++ b/tests/Utilities/StrTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Memuya\Fab\Utilities\Str;
+use PHPUnit\Framework\TestCase;
+
+final class StrTest extends TestCase
+{
+    public function setUp(): void
+    {
+        
+    }
+
+    /** @test */
+    public function testToPascalCase()
+    {
+        $snake_case = 'a_test_string';
+        $dashes = 'a-test-string';
+        $camel_case = 'aTestString';
+        $expected = 'ATestString';
+
+        $this->assertSame($expected, Str::toPascalCase($snake_case));
+        $this->assertSame($expected, Str::toPascalCase($dashes));
+        $this->assertSame($expected, Str::toPascalCase($camel_case));
+    }
+}

--- a/tests/Utilities/StrTest.php
+++ b/tests/Utilities/StrTest.php
@@ -22,4 +22,22 @@ final class StrTest extends TestCase
         $this->assertSame($expected, Str::toPascalCase($dashes));
         $this->assertSame($expected, Str::toPascalCase($camel_case));
     }
+
+    /** @test */
+    public function testRemoveWhiteSpace()
+    {
+        $original_string = 'hello world';
+        $expected = 'helloworld';
+
+        $this->assertSame($expected, Str::removeWhiteSpace($original_string));
+    }
+
+    /** @test */
+    public function testReplace()
+    {
+        $original_string = 'hello world';
+        $expected = 'hello all';
+
+        $this->assertSame($expected, Str::replace($original_string, 'world', 'all'));
+    }
 }

--- a/tests/Utilities/ValueTest.php
+++ b/tests/Utilities/ValueTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Memuya\Fab\Enums\HeroClass;
+use PHPUnit\Framework\TestCase;
+use Memuya\Fab\Utilities\Extract\Value;
+
+final class ValueTest extends TestCase
+{
+    /** @test */
+    public function testCanExtractValueFromBackedEnum()
+    {
+        $this->assertSame(
+            HeroClass::Illusionist->value,
+            Value::from(HeroClass::Illusionist)->extract()
+        );
+    }
+
+    /** @test */
+    public function testCanExtractValueFromUnitEnum()
+    {
+        $this->assertSame(
+            TestUnitEnum::ACase->name,
+            Value::from(TestUnitEnum::ACase)->extract()
+        );
+    }
+
+    /** @test */
+    public function testCanExtractValueFromStringable()
+    {
+        $stringable_object = new class implements \Stringable
+        {
+            public function __toString()
+            {
+                return 'test';
+            }
+        };
+
+        $this->assertSame(
+            'test',
+            Value::from($stringable_object)->extract()
+        );
+    }
+}
+
+enum TestUnitEnum {
+    case ACase;
+}


### PR DESCRIPTION
This will require a major version bump.

## Updates made to follow the fabdb documentation
Some of these changes are not listed in the docuentation but work with the API.
- The `\Memuya\Fab\Client` now requires a token and secret.
- The query string sent is now hashed as described in the documentation.
- The `\Memuya\Fab\Enums\CardType` enum was added to be used with the `\Memuya\Fab\Endpoints\Cards\CardsConfig` class.
- The `\Memuya\Fab\Enums\Talent` enum was added to be used with the `\Memuya\Fab\Endpoints\Cards\CardsConfig` class.

## Internal changes
- An `Extract` utility was added to aid with extracting types out of certain classes (i.e. enums and backed enums).
- The formatter classes now use the `HttpContentType` enum to define their content types.
- Renamed `\Memuya\Fab\Endpoints\BaseConfig` to `\Memuya\Fab\Endpoints\Config`.
- Added a basic string utility class (`\Memuya\Fab\Utilities\Str`).