### PR TITLE
v4.1.0

### DIFF
--- a/src/Clients/TheFabCube/Endpoints/Cards/CardsConfig.php
+++ b/src/Clients/TheFabCube/Endpoints/Cards/CardsConfig.php
@@ -33,12 +33,12 @@ class CardsConfig extends Config
     public string $cost;
 
     /**
-     * The set ID to filter by.
+     * The card ID to filter by.
      *
      * @var string
      */
     #[Parameter]
-    public string $set_id;
+    public string $card_id;
 
     /**
      * The power to filter by.

--- a/src/Clients/TheFabCube/Filters/CardIdFilter.php
+++ b/src/Clients/TheFabCube/Filters/CardIdFilter.php
@@ -4,14 +4,14 @@ namespace Memuya\Fab\Clients\TheFabCube\Filters;
 
 use Memuya\Fab\Clients\File\Filters\Filterable;
 
-class SetNumberFilter implements Filterable
+class CardIdFilter implements Filterable
 {
     /**
      * @inheritDoc
      */
     public function canResolve(array $filters): bool
     {
-        return isset($filters['set_id']) && ! is_null($filters['set_id']);
+        return isset($filters['card_id']) && ! is_null($filters['card_id']);
     }
 
     /**
@@ -21,7 +21,7 @@ class SetNumberFilter implements Filterable
     {
         return array_filter($data, function ($card) use ($filters) {
             foreach ($card['printings'] as $printing) {
-                if ($printing['id'] === $filters['set_id']) {
+                if ($printing['id'] === $filters['card_id']) {
                     return true;
                 }
             }

--- a/src/Clients/TheFabCube/Filters/DefenseFilter.php
+++ b/src/Clients/TheFabCube/Filters/DefenseFilter.php
@@ -4,14 +4,14 @@ namespace Memuya\Fab\Clients\TheFabCube\Filters;
 
 use Memuya\Fab\Clients\File\Filters\Filterable;
 
-class DefenceFilter implements Filterable
+class DefenseFilter implements Filterable
 {
     /**
      * @inheritDoc
      */
     public function canResolve(array $filters): bool
     {
-        return isset($filters['defence']) && ! is_null($filters['defence']);
+        return isset($filters['defense']) && ! is_null($filters['defense']);
     }
 
     /**
@@ -20,7 +20,7 @@ class DefenceFilter implements Filterable
     public function applyTo(array $data, array $filters): array
     {
         return array_filter($data, function ($card) use ($filters) {
-            return $card['defence'] === $filters['defence'];
+            return $card['defense'] === $filters['defense'];
         });
     }
 }

--- a/src/Clients/TheFabCube/TheFabCubeClient.php
+++ b/src/Clients/TheFabCube/TheFabCubeClient.php
@@ -14,14 +14,14 @@ use Memuya\Fab\Clients\TheFabCube\Filters\TypeFilter;
 use Memuya\Fab\Clients\TheFabCube\Filters\PitchFilter;
 use Memuya\Fab\Clients\TheFabCube\Filters\PowerFilter;
 use Memuya\Fab\Clients\TheFabCube\Filters\ArcaneFilter;
+use Memuya\Fab\Clients\TheFabCube\Filters\CardIdFilter;
 use Memuya\Fab\Clients\TheFabCube\Filters\HealthFilter;
 use Memuya\Fab\Clients\TheFabCube\Filters\CcLegalFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\DefenceFilter;
+use Memuya\Fab\Clients\TheFabCube\Filters\DefenseFilter;
 use Memuya\Fab\Clients\TheFabCube\Filters\CcBannedFilter;
 use Memuya\Fab\Clients\TheFabCube\Filters\LlBannedFilter;
 use Memuya\Fab\Clients\TheFabCube\Filters\TypeTextFilter;
 use Memuya\Fab\Clients\TheFabCube\Filters\UniqueIdFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\SetNumberFilter;
 use Memuya\Fab\Clients\TheFabCube\Filters\UpfBannedFilter;
 use Memuya\Fab\Clients\TheFabCube\Filters\BlitzLegalFilter;
 use Memuya\Fab\Clients\TheFabCube\Endpoints\Card\CardConfig;
@@ -133,6 +133,7 @@ class TheFabCubeClient implements Client
             new BlitzLegalFilter(),
             new BlitzLivingLegendFilter(),
             new BlitzSuspendedFilter(),
+            new CardIdFilter(),
             new CardKeywordsFilter(),
             new CcBannedFilter(),
             new CcLegalFilter(),
@@ -142,7 +143,7 @@ class TheFabCubeClient implements Client
             new CommonerLegalFilter(),
             new CommonerSuspendedFilter(),
             new CostFilter(),
-            new DefenceFilter(),
+            new DefenseFilter(),
             new FunctionalTextFilter(),
             new FunctionalTextPlainFilter(),
             new GrantedKeywordsFilter(),
@@ -157,7 +158,6 @@ class TheFabCubeClient implements Client
             new PlayedHorizontallyFilter(),
             new PowerFilter(),
             new RemovedKeywordsFilter(),
-            new SetNumberFilter(),
             new TypeFilter(),
             new TypeTextFilter(),
             new UniqueIdFilter(),

--- a/src/Exceptions/ConfigNotRegisteredException.php
+++ b/src/Exceptions/ConfigNotRegisteredException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Memuya\Fab\Exceptions;
+
+use Exception;
+
+class ConfigNotRegisteredException extends Exception {}

--- a/tests/Clients/TheFabCube/Endpoints/Cards/CardsConfigTest.php
+++ b/tests/Clients/TheFabCube/Endpoints/Cards/CardsConfigTest.php
@@ -10,30 +10,166 @@ final class CardsConfigTest extends TestCase
     {
         $name = 'test';
         $config = new CardsConfig(['name' => $name]);
-
         $this->assertSame($name, $config->name);
     }
 
     public function testCanSetValidPitch()
     {
         $config = new CardsConfig(['pitch' => Pitch::One]);
-
         $this->assertSame(Pitch::One, $config->pitch);
     }
 
     public function testCanSetValidCost()
     {
-        $cost = '2';
+        $cost = '3';
         $config = new CardsConfig(['cost' => $cost]);
-
         $this->assertSame($cost, $config->cost);
+    }
+
+    public function testCanSetValidSetId()
+    {
+        $cardId = 'set123';
+        $config = new CardsConfig(['card_id' => $cardId]);
+        $this->assertSame($cardId, $config->card_id);
     }
 
     public function testCanSetValidPower()
     {
-        $power = '2';
+        $power = '5';
         $config = new CardsConfig(['power' => $power]);
-
         $this->assertSame($power, $config->power);
+    }
+
+    public function testCanSetValidUniqueId()
+    {
+        $uniqueId = 'unique456';
+        $config = new CardsConfig(['unique_id' => $uniqueId]);
+        $this->assertSame($uniqueId, $config->unique_id);
+    }
+
+    public function testCanSetValidDefense()
+    {
+        $defense = '3';
+        $config = new CardsConfig(['defense' => $defense]);
+        $this->assertSame($defense, $config->defense);
+    }
+
+    public function testCanSetValidHealth()
+    {
+        $health = '7';
+        $config = new CardsConfig(['health' => $health]);
+        $this->assertSame($health, $config->health);
+    }
+
+    public function testCanSetValidIntelligence()
+    {
+        $intelligence = '4';
+        $config = new CardsConfig(['intelligence' => $intelligence]);
+        $this->assertSame($intelligence, $config->intelligence);
+    }
+
+    public function testCanSetValidArcane()
+    {
+        $arcane = '2';
+        $config = new CardsConfig(['arcane' => $arcane]);
+        $this->assertSame($arcane, $config->arcane);
+    }
+
+    public function testCanSetValidTypes()
+    {
+        $types = ['attack', 'action'];
+        $config = new CardsConfig(['types' => $types]);
+        $this->assertSame($types, $config->types);
+    }
+
+    public function testCanSetValidCardKeywords()
+    {
+        $keywords = ['keyword1', 'keyword2'];
+        $config = new CardsConfig(['card_keywords' => $keywords]);
+        $this->assertSame($keywords, $config->card_keywords);
+    }
+
+    public function testCanSetValidAbilitiesAndEffects()
+    {
+        $effects = ['effect1', 'effect2'];
+        $config = new CardsConfig(['abilities_and_effects' => $effects]);
+        $this->assertSame($effects, $config->abilities_and_effects);
+    }
+
+    public function testCanSetValidAbilityAndEffectKeywords()
+    {
+        $keywords = ['ability1', 'effect2'];
+        $config = new CardsConfig(['ability_and_effect_keywords' => $keywords]);
+        $this->assertSame($keywords, $config->ability_and_effect_keywords);
+    }
+
+    public function testCanSetValidGrantedKeywords()
+    {
+        $grantedKeywords = ['granted1', 'granted2'];
+        $config = new CardsConfig(['granted_keywords' => $grantedKeywords]);
+        $this->assertSame($grantedKeywords, $config->granted_keywords);
+    }
+
+    public function testCanSetValidRemovedKeywords()
+    {
+        $removedKeywords = ['removed1', 'removed2'];
+        $config = new CardsConfig(['removed_keywords' => $removedKeywords]);
+        $this->assertSame($removedKeywords, $config->removed_keywords);
+    }
+
+    public function testCanSetValidInteractsWithKeywords()
+    {
+        $keywords = ['keyword1', 'keyword3'];
+        $config = new CardsConfig(['interacts_with_keywords' => $keywords]);
+        $this->assertSame($keywords, $config->interacts_with_keywords);
+    }
+
+    public function testCanSetValidFunctionalText()
+    {
+        $text = 'Some functional text';
+        $config = new CardsConfig(['functional_text' => $text]);
+        $this->assertSame($text, $config->functional_text);
+    }
+
+    public function testCanSetValidFunctionalTextPlain()
+    {
+        $text = 'Plain functional text';
+        $config = new CardsConfig(['functional_text_plain' => $text]);
+        $this->assertSame($text, $config->functional_text_plain);
+    }
+
+    public function testCanSetValidTypeText()
+    {
+        $typeText = 'Action';
+        $config = new CardsConfig(['type_text' => $typeText]);
+        $this->assertSame($typeText, $config->type_text);
+    }
+
+    public function testCanSetValidBooleanFields()
+    {
+        $fields = [
+            'played_horizontally' => true,
+            'blitz_legal' => false,
+            'cc_legal' => true,
+            'commoner_legal' => false,
+            'll_legal' => true,
+            'blitz_living_legend' => false,
+            'cc_living_legend' => true,
+            'blitz_banned' => false,
+            'cc_banned' => true,
+            'commoner_banned' => false,
+            'll_banned' => true,
+            'upf_banned' => false,
+            'blitz_suspended' => true,
+            'cc_suspended' => false,
+            'commoner_suspended' => true,
+            'll_restricted' => false,
+        ];
+
+        foreach ($fields as $field => $value) {
+            $config = new CardsConfig([$field => $value]);
+
+            $this->assertSame($value, $config->{$field});
+        }
     }
 }

--- a/tests/Utilities/StrTest.php
+++ b/tests/Utilities/StrTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Memuya\Fab\Utilities\Str;
+use PHPUnit\Framework\TestCase;
+
+final class StrTest extends TestCase
+{
+    public function setUp(): void {}
+
+    public function testToPascalCase()
+    {
+        $snake_case = 'a_test_string';
+        $dashes = 'a-test-string';
+        $camel_case = 'aTestString';
+        $expected = 'ATestString';
+
+        $this->assertSame($expected, Str::toPascalCase($snake_case));
+        $this->assertSame($expected, Str::toPascalCase($dashes));
+        $this->assertSame($expected, Str::toPascalCase($camel_case));
+    }
+
+    public function testToCamelCase()
+    {
+        $snake_case = 'a_test_string';
+        $dashes = 'a-test-string';
+        $pascal_case = 'ATestString';
+        $expected = 'aTestString';
+
+        $this->assertSame($expected, Str::toCamelCase($snake_case));
+        $this->assertSame($expected, Str::toCamelCase($dashes));
+        $this->assertSame($expected, Str::toCamelCase($pascal_case));
+    }
+
+    public function testRemoveWhiteSpace()
+    {
+        $original_string = 'hello world';
+        $expected = 'helloworld';
+
+        $this->assertSame($expected, Str::removeWhiteSpace($original_string));
+    }
+
+    public function testReplace()
+    {
+        $original_string = 'hello world';
+        $expected = 'hello all';
+
+        $this->assertSame($expected, Str::replace($original_string, 'world', 'all'));
+    }
+}


### PR DESCRIPTION
- Code clean up.
- Expanded on the `tests\Clients\TheFabCube\Endpoints\Cards\CardsConfigTest.php` test.
- Renamed `SetNumberFilter()` to `CardIdFilter()` to better align with the JSON property name.
- Renamed `DefenceFilter()` to `DefenseFilter()` and fixed the name of the property it was checking against.
- `FileClient::resolveConfig()` now throws `ConfigNotRegisteredException`.
- Added test for `Str` class.
- Bumped PHP version to 8.2 in `composer.json`.

