### PR TITLE
v4.2.0.

### DIFF
--- a/src/Clients/File/Filters/Filterable.php
+++ b/src/Clients/File/Filters/Filterable.php
@@ -17,7 +17,7 @@ interface Filterable
      *
      * @param array<string, mixed> $data
      * @param array<string, mixed> $filter
-     * @return array
+     * @return array<string, mixed>
      */
     public function applyTo(array $data, array $filters): array;
 }

--- a/src/Clients/File/Filters/Filterable.php
+++ b/src/Clients/File/Filters/Filterable.php
@@ -15,9 +15,9 @@ interface Filterable
     /**
      * Apply the filter to the query.
      *
-     * @param array $data
+     * @param array<string, mixed> $data
      * @param array<string, mixed> $filter
-     * @return void
+     * @return array
      */
     public function applyTo(array $data, array $filters): array;
 }

--- a/src/Clients/TheFabCube/Endpoints/Cards/CardsConfig.php
+++ b/src/Clients/TheFabCube/Endpoints/Cards/CardsConfig.php
@@ -2,7 +2,9 @@
 
 namespace Memuya\Fab\Clients\TheFabCube\Endpoints\Cards;
 
+use Memuya\Fab\Enums\Set;
 use Memuya\Fab\Enums\Pitch;
+use Memuya\Fab\Enums\Rarity;
 use Memuya\Fab\Clients\Config;
 use Memuya\Fab\Attributes\Parameter;
 
@@ -295,4 +297,20 @@ class CardsConfig extends Config
      */
     #[Parameter]
     public bool $ll_restricted;
+
+    /**
+     * The set to filter by.
+     *
+     * @var Set
+     */
+    #[Parameter]
+    public Set $set;
+
+    /**
+     * The rarity to filter by.
+     *
+     * @var Rarity
+     */
+    #[Parameter]
+    public Rarity $rarity;
 }

--- a/src/Clients/TheFabCube/Entities/Card.php
+++ b/src/Clients/TheFabCube/Entities/Card.php
@@ -13,12 +13,19 @@ class Card extends Entity
     public ?string $health;
     public ?string $intelligence;
     public ?string $arcane;
+    /** @var array<string> */
     public array $types = [];
+    /** @var array<string> */
     public array $cardKeywords = [];
+    /** @var array<string> */
     public array $abilitiesAndEffects = [];
+    /** @var array<string> */
     public array $abilityAndEffectKeywords = [];
+    /** @var array<string> */
     public array $grantedKeywords = [];
+    /** @var array<string> */
     public array $removedKeywords = [];
+    /** @var array<string> */
     public array $interactsWithKeywords = [];
     public string $functionalText;
     public string $functionalTextPlain;
@@ -39,6 +46,7 @@ class Card extends Entity
     public bool $ccSuspended;
     public bool $commonerSuspended;
     public bool $llRestricted;
+    /** @var array<Printing> */
     public array $printings = [];
 
     public function __construct(array $data)

--- a/src/Clients/TheFabCube/Entities/Entity.php
+++ b/src/Clients/TheFabCube/Entities/Entity.php
@@ -10,7 +10,7 @@ abstract class Entity
     {
         foreach ($data as $key => $value) {
             $property = Str::toCamelCase($key);
-            
+
             if (property_exists($this, $property)) {
                 $method = sprintf('set%s', Str::toPascalCase($key));
 

--- a/src/Clients/TheFabCube/Entities/Entity.php
+++ b/src/Clients/TheFabCube/Entities/Entity.php
@@ -8,19 +8,43 @@ abstract class Entity
 {
     public function __construct(array $data)
     {
+        $this->setProperties($data);
+    }
+
+    /**
+     * Set multiple properties.
+     *
+     * @param array<string, mixed> $data
+     * @return void
+     */
+    protected function setProperties(array $data): void
+    {
         foreach ($data as $key => $value) {
-            $property = Str::toCamelCase($key);
+            $this->setProperty($key, $value);
+        }
+    }
 
-            if (property_exists($this, $property)) {
-                $method = sprintf('set%s', Str::toPascalCase($key));
+    /**
+     * Set a property, trying to use an associated setter if present.
+     *
+     * @param string $propertyName
+     * @param mixed $value
+     * @return void
+     */
+    protected function setProperty(string $propertyName, mixed $value): void
+    {
+        $property = Str::toCamelCase($propertyName);
 
-                if (method_exists($this, $method)) {
-                    $this->{$method}($value);
-                    continue;
-                }
+        if (property_exists($this, $property)) {
+            $method = sprintf('set%s', Str::toPascalCase($propertyName));
 
-                $this->{$property} = $value;
+            if (method_exists($this, $method)) {
+                $this->{$method}($value);
+
+                return;
             }
+
+            $this->{$property} = $value;
         }
     }
 }

--- a/src/Clients/TheFabCube/Entities/Printing.php
+++ b/src/Clients/TheFabCube/Entities/Printing.php
@@ -12,7 +12,9 @@ class Printing extends Entity
     public string $foiling;
     public string $rarity;
     public bool $expansionSlot;
+    /** @var array<string> */
     public array $artists = [];
+    /** @var array<string> */
     public array $artVariations = [];
     public string $flavorText;
     public string $flavorTextPlain;

--- a/src/Clients/TheFabCube/Filters/AbilitiesAndEffectsFilter.php
+++ b/src/Clients/TheFabCube/Filters/AbilitiesAndEffectsFilter.php
@@ -14,7 +14,7 @@ class AbilitiesAndEffectsFilter implements Filterable
      */
     public function canResolve(array $filters): bool
     {
-        return isset($filters['abilities_and_effects']) && ! is_null($filters['abilities_and_effects']);
+        return isset($filters['abilities_and_effects']) && is_array($filters['abilities_and_effects']);
     }
 
     /**

--- a/src/Clients/TheFabCube/Filters/AbilitiesAndEffectsKeywordsFilter.php
+++ b/src/Clients/TheFabCube/Filters/AbilitiesAndEffectsKeywordsFilter.php
@@ -14,7 +14,7 @@ class AbilitiesAndEffectsKeywordsFilter implements Filterable
      */
     public function canResolve(array $filters): bool
     {
-        return isset($filters['ability_and_effect_keywords']) && ! is_null($filters['ability_and_effect_keywords']);
+        return isset($filters['ability_and_effect_keywords']) && is_array($filters['ability_and_effect_keywords']);
     }
 
     /**

--- a/src/Clients/TheFabCube/Filters/CardKeywordsFilter.php
+++ b/src/Clients/TheFabCube/Filters/CardKeywordsFilter.php
@@ -14,7 +14,7 @@ class CardKeywordsFilter implements Filterable
      */
     public function canResolve(array $filters): bool
     {
-        return isset($filters['card_keywords']) && ! is_null($filters['card_keywords']);
+        return isset($filters['card_keywords']) && is_array($filters['card_keywords']);
     }
 
     /**

--- a/src/Clients/TheFabCube/Filters/GrantedKeywordsFilter.php
+++ b/src/Clients/TheFabCube/Filters/GrantedKeywordsFilter.php
@@ -14,7 +14,7 @@ class GrantedKeywordsFilter implements Filterable
      */
     public function canResolve(array $filters): bool
     {
-        return isset($filters['granted_keywords']) && ! is_null($filters['granted_keywords']);
+        return isset($filters['granted_keywords']) && is_array($filters['granted_keywords']);
     }
 
     /**

--- a/src/Clients/TheFabCube/Filters/InteractsWithKeywordsFilter.php
+++ b/src/Clients/TheFabCube/Filters/InteractsWithKeywordsFilter.php
@@ -14,7 +14,7 @@ class InteractsWithKeywordsFilter implements Filterable
      */
     public function canResolve(array $filters): bool
     {
-        return isset($filters['interacts_with_keywords']) && ! is_null($filters['interacts_with_keywords']);
+        return isset($filters['interacts_with_keywords']) && is_array($filters['interacts_with_keywords']);
     }
 
     /**

--- a/src/Clients/TheFabCube/Filters/NameFilter.php
+++ b/src/Clients/TheFabCube/Filters/NameFilter.php
@@ -20,7 +20,7 @@ class NameFilter implements Filterable
     public function applyTo(array $data, array $filters): array
     {
         return array_filter($data, function ($card) use ($filters) {
-            return str_contains($card['name'], $filters['name']);
+            return str_contains(strtolower($card['name']), strtolower($filters['name']));
         });
     }
 }

--- a/src/Clients/TheFabCube/Filters/RarityFilter.php
+++ b/src/Clients/TheFabCube/Filters/RarityFilter.php
@@ -4,14 +4,14 @@ namespace Memuya\Fab\Clients\TheFabCube\Filters;
 
 use Memuya\Fab\Clients\File\Filters\Filterable;
 
-class PowerFilter implements Filterable
+class RarityFilter implements Filterable
 {
     /**
      * @inheritDoc
      */
     public function canResolve(array $filters): bool
     {
-        return isset($filters['power']) && ! is_null($filters['power']);
+        return isset($filters['rarity']) && ! is_null($filters['rarity']);
     }
 
     /**
@@ -20,7 +20,13 @@ class PowerFilter implements Filterable
     public function applyTo(array $data, array $filters): array
     {
         return array_filter($data, function ($card) use ($filters) {
-            return $card['power'] === $filters['power'];
+            foreach ($card['printings'] as $printing) {
+                if ($printing['rarity'] === $filters['rarity']) {
+                    return true;
+                }
+            }
+
+            return false;
         });
     }
 }

--- a/src/Clients/TheFabCube/Filters/RemovedKeywordsFilter.php
+++ b/src/Clients/TheFabCube/Filters/RemovedKeywordsFilter.php
@@ -14,7 +14,7 @@ class RemovedKeywordsFilter implements Filterable
      */
     public function canResolve(array $filters): bool
     {
-        return isset($filters['removed_keywords']) && ! is_null($filters['removed_keywords']);
+        return isset($filters['removed_keywords']) && is_array($filters['removed_keywords']);
     }
 
     /**

--- a/src/Clients/TheFabCube/Filters/SetFilter.php
+++ b/src/Clients/TheFabCube/Filters/SetFilter.php
@@ -4,14 +4,14 @@ namespace Memuya\Fab\Clients\TheFabCube\Filters;
 
 use Memuya\Fab\Clients\File\Filters\Filterable;
 
-class PowerFilter implements Filterable
+class SetFilter implements Filterable
 {
     /**
      * @inheritDoc
      */
     public function canResolve(array $filters): bool
     {
-        return isset($filters['power']) && ! is_null($filters['power']);
+        return isset($filters['set']) && ! is_null($filters['set']);
     }
 
     /**
@@ -20,7 +20,13 @@ class PowerFilter implements Filterable
     public function applyTo(array $data, array $filters): array
     {
         return array_filter($data, function ($card) use ($filters) {
-            return $card['power'] === $filters['power'];
+            foreach ($card['printings'] as $printing) {
+                if ($printing['set_id'] === $filters['set']) {
+                    return true;
+                }
+            }
+
+            return false;
         });
     }
 }

--- a/src/Clients/TheFabCube/Filters/TypeFilter.php
+++ b/src/Clients/TheFabCube/Filters/TypeFilter.php
@@ -14,7 +14,7 @@ class TypeFilter implements Filterable
      */
     public function canResolve(array $filters): bool
     {
-        return isset($filters['types']) && ! is_null($filters['types']);
+        return isset($filters['types']) && is_array($filters['types']);
     }
 
     /**

--- a/src/Clients/TheFabCube/TheFabCubeClient.php
+++ b/src/Clients/TheFabCube/TheFabCubeClient.php
@@ -6,45 +6,9 @@ use Memuya\Fab\Clients\Client;
 use Memuya\Fab\Clients\File\ConfigType;
 use Memuya\Fab\Clients\File\FileClient;
 use Memuya\Fab\Clients\TheFabCube\Entities\Card;
-use Memuya\Fab\Clients\TheFabCube\Filters\LlLegal;
-use Memuya\Fab\Clients\TheFabCube\Filters\CostFilter;
 use Memuya\Fab\Clients\TheFabCube\Filters\Filterable;
-use Memuya\Fab\Clients\TheFabCube\Filters\NameFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\TypeFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\PitchFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\PowerFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\ArcaneFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\CardIdFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\HealthFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\CcLegalFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\DefenseFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\CcBannedFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\LlBannedFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\TypeTextFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\UniqueIdFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\UpfBannedFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\BlitzLegalFilter;
 use Memuya\Fab\Clients\TheFabCube\Endpoints\Card\CardConfig;
-use Memuya\Fab\Clients\TheFabCube\Filters\BlitzBannedFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\CcSuspendedFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\CardKeywordsFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\IntelligenceFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\LlRestrictedFilter;
 use Memuya\Fab\Clients\TheFabCube\Endpoints\Cards\CardsConfig;
-use Memuya\Fab\Clients\TheFabCube\Filters\CommonerLegalFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\BlitzSuspendedFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\CcLivingLegendFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\CommonerBannedFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\FunctionalTextFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\GrantedKeywordsFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\RemovedKeywordsFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\BlitzLivingLegendFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\CommonerSuspendedFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\PlayedHorizontallyFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\AbilitiesAndEffectsFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\FunctionalTextPlainFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\InteractsWithKeywordsFilter;
-use Memuya\Fab\Clients\TheFabCube\Filters\AbilitiesAndEffectsKeywordsFilter;
 
 /**
  * The FAB Cube is a Git repo that store an up-to-date list of all Flesh and Blood cards.
@@ -79,7 +43,10 @@ class TheFabCubeClient implements Client
     {
         $cards = $this->fileClient->getCards($filters);
 
-        return array_map(fn(array $card): Card => new Card($card), $cards);
+        return array_map(
+            fn(array $card): Card => new Card($card),
+            $cards,
+        );
     }
 
     /**
@@ -126,42 +93,44 @@ class TheFabCubeClient implements Client
     private function getDefaultFilters(): array
     {
         return [
-            new AbilitiesAndEffectsFilter(),
-            new AbilitiesAndEffectsKeywordsFilter(),
-            new ArcaneFilter(),
-            new BlitzBannedFilter(),
-            new BlitzLegalFilter(),
-            new BlitzLivingLegendFilter(),
-            new BlitzSuspendedFilter(),
-            new CardIdFilter(),
-            new CardKeywordsFilter(),
-            new CcBannedFilter(),
-            new CcLegalFilter(),
-            new CcLivingLegendFilter(),
-            new CcSuspendedFilter(),
-            new CommonerBannedFilter(),
-            new CommonerLegalFilter(),
-            new CommonerSuspendedFilter(),
-            new CostFilter(),
-            new DefenseFilter(),
-            new FunctionalTextFilter(),
-            new FunctionalTextPlainFilter(),
-            new GrantedKeywordsFilter(),
-            new HealthFilter(),
-            new IntelligenceFilter(),
-            new InteractsWithKeywordsFilter(),
-            new LlBannedFilter(),
-            new LlLegal(),
-            new LlRestrictedFilter(),
-            new NameFilter(),
-            new PitchFilter(),
-            new PlayedHorizontallyFilter(),
-            new PowerFilter(),
-            new RemovedKeywordsFilter(),
-            new TypeFilter(),
-            new TypeTextFilter(),
-            new UniqueIdFilter(),
-            new UpfBannedFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\AbilitiesAndEffectsFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\AbilitiesAndEffectsKeywordsFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\ArcaneFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\BlitzBannedFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\BlitzLegalFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\BlitzLivingLegendFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\BlitzSuspendedFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\CardIdFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\CardKeywordsFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\CcBannedFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\CcLegalFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\CcLivingLegendFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\CcSuspendedFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\CommonerBannedFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\CommonerLegalFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\CommonerSuspendedFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\CostFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\DefenseFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\FunctionalTextFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\FunctionalTextPlainFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\GrantedKeywordsFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\HealthFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\IntelligenceFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\InteractsWithKeywordsFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\LlBannedFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\LlLegal(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\LlRestrictedFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\NameFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\PitchFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\PlayedHorizontallyFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\PowerFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\RarityFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\RemovedKeywordsFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\SetFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\TypeFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\TypeTextFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\UniqueIdFilter(),
+            new \Memuya\Fab\Clients\TheFabCube\Filters\UpfBannedFilter(),
         ];
     }
 }

--- a/src/Enums/Set.php
+++ b/src/Enums/Set.php
@@ -10,12 +10,15 @@ enum Set: string
     case TalesOfAria = 'ELE';
     case Monarch = 'MON';
     case Everfest = 'EVR';
+    case HistoryPackOne = '1HP';
     case Uprising = 'UPR';
     case Dynasty = 'DYN';
     case Outsiders = 'OUT';
     case DuskTillDawn = 'DTD';
     case BrightLights = 'EVO';
+    case RoundTheTable = 'TCC';
     case HeavyHitters = 'HVY';
     case PartTheMistveil = 'MST';
     case Rosetta = 'ROS';
+    case TheHunted = 'HNT';
 }

--- a/tests/Clients/TheFabCube/Endpoints/Cards/CardsConfigTest.php
+++ b/tests/Clients/TheFabCube/Endpoints/Cards/CardsConfigTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Memuya\Fab\Enums\Set;
 use Memuya\Fab\Enums\Pitch;
+use Memuya\Fab\Enums\Rarity;
 use PHPUnit\Framework\TestCase;
 use Memuya\Fab\Clients\TheFabCube\Endpoints\Cards\CardsConfig;
 
@@ -143,6 +145,18 @@ final class CardsConfigTest extends TestCase
         $typeText = 'Action';
         $config = new CardsConfig(['type_text' => $typeText]);
         $this->assertSame($typeText, $config->type_text);
+    }
+
+    public function testCanSetValidSet()
+    {
+        $config = new CardsConfig(['set' => Set::Monarch]);
+        $this->assertSame(Set::Monarch, $config->set);
+    }
+
+    public function testCanSetValidRarity()
+    {
+        $config = new CardsConfig(['rarity' => Rarity::Fabled]);
+        $this->assertSame(Rarity::Fabled, $config->rarity);
     }
 
     public function testCanSetValidBooleanFields()

--- a/tests/Clients/TheFabCube/TheFabCubeClientTest.php
+++ b/tests/Clients/TheFabCube/TheFabCubeClientTest.php
@@ -13,7 +13,6 @@ final class TheFabCubeClientTest extends TestCase
     public function setUp(): void
     {
         $this->cardsJsonFilePath = sprintf('%s/the_fab_cube_cards.json', dirname(__DIR__, 2));
-
         $this->client = new TheFabCubeClient($this->cardsJsonFilePath);
     }
 

--- a/tests/Clients/TheFabCube/TheFabCubeClientTest.php
+++ b/tests/Clients/TheFabCube/TheFabCubeClientTest.php
@@ -49,7 +49,8 @@ final class TheFabCubeClientTest extends TestCase
 
     public function testCanReturnASingleCard(): void
     {
-        $card = $this->client->getCard('Luminaris');
+        // Purposely using a lowercase name.
+        $card = $this->client->getCard('luminaris');
 
         $this->assertInstanceOf(Card::class, $card);
         $this->assertSame('Luminaris', $card->name);


### PR DESCRIPTION
- Can now filter by `set` and `rarity` in ` Memuya\Fab\Clients\TheFabCube\Endpoints\Cards\CardsConfig`.
```php
$client = new \Memuya\Fab\Clients\TheFabCube\TheFabCubeClient('/path/to/card.json');
$client->getCards([
    'set' => \Memuya\Fab\Enums\Set::Monarch,
    'rarity' => \Memuya\Fab\Enums\Rarity::Fabled,
]);
```
- Fixed a few filter's `canResolve()` check for arrays.
- `Memuya\Fab\Clients\TheFabCube\Filters\NameFilter` is now case-insensitive.
- Added `1HP`, `TCC` and `HNT` to `Memuya\Fab\Enums\Set`.